### PR TITLE
upgraded nginx to 1.21.3

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=nginx
 pkg_origin=core
-pkg_version=1.21.0
+pkg_version=1.21.3
 pkg_description="NGINX web server."
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('BSD-2-Clause')
 pkg_source="https://nginx.org/download/nginx-${pkg_version}.tar.gz"
 pkg_upstream_url=https://nginx.org/
-pkg_shasum=fe192a4bac2bd3a769e8695cb9fe14a00e57eaceb919095347a83b5b2afc0771
+pkg_shasum=14774aae0d151da350417efc4afda5cce5035056e71894836797e1f6e2d1175a
 pkg_deps=(
   core/glibc
   core/libedit


### PR DESCRIPTION
upgraded nginx to v1.21.3 to fix CVE-2021-23017

Signed-off-by: Nimit <nimit.jyotiana@hotmail.com>